### PR TITLE
Add metrics tracking for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # DynamicReasoning
 Build 2 agents, 1 with static workflow and one with Dynamic Reasoning, measure the results
+
+## Metrics
+
+The `metrics.py` module tracks conversation statistics for both agents. It records turns, task completion, error count and placeholder CSAT scores. Each agent returns a summary dictionary after `converse` showing these metrics.

--- a/dynamic_agent.py
+++ b/dynamic_agent.py
@@ -1,0 +1,21 @@
+from metrics import Metrics
+
+
+class DynamicAgent:
+    """Simple agent using a dynamic script."""
+
+    def __init__(self, metrics: Metrics):
+        self.metrics = metrics
+
+    def converse(self, script):
+        """Run through a list of actions.
+
+        `script` is an iterable containing strings. When the string is
+        "error" an error is recorded.
+        """
+        for step in script:
+            self.metrics.record_turn()
+            if step == "error":
+                self.metrics.record_error()
+        self.metrics.record_task_completed()
+        return self.metrics.summary()

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,34 @@
+class Metrics:
+    """Track conversation statistics."""
+
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        self.tasks_completed = 0
+        self.turns = 0
+        self.errors = 0
+        self.csat_scores = []  # placeholder for future CSAT metrics
+
+    def record_turn(self):
+        self.turns += 1
+
+    def record_task_completed(self):
+        self.tasks_completed += 1
+
+    def record_error(self):
+        self.errors += 1
+
+    def record_csat(self, score):
+        self.csat_scores.append(score)
+
+    def summary(self):
+        avg_csat = None
+        if self.csat_scores:
+            avg_csat = sum(self.csat_scores) / len(self.csat_scores)
+        return {
+            "tasks_completed": self.tasks_completed,
+            "turns": self.turns,
+            "errors": self.errors,
+            "avg_csat": avg_csat,
+        }

--- a/static_agent.py
+++ b/static_agent.py
@@ -1,0 +1,15 @@
+from metrics import Metrics
+
+
+class StaticAgent:
+    """Agent with a static predetermined number of turns."""
+
+    def __init__(self, metrics: Metrics, turns: int = 1):
+        self.metrics = metrics
+        self.turns = turns
+
+    def converse(self):
+        for _ in range(self.turns):
+            self.metrics.record_turn()
+        self.metrics.record_task_completed()
+        return self.metrics.summary()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,29 @@
+import unittest
+
+from metrics import Metrics
+from dynamic_agent import DynamicAgent
+from static_agent import StaticAgent
+
+
+class MetricsTests(unittest.TestCase):
+    def test_static_agent_metrics(self):
+        metrics = Metrics()
+        agent = StaticAgent(metrics, turns=3)
+        summary = agent.converse()
+        self.assertEqual(summary["turns"], 3)
+        self.assertEqual(summary["tasks_completed"], 1)
+        self.assertEqual(summary["errors"], 0)
+        self.assertIsNone(summary["avg_csat"])
+
+    def test_dynamic_agent_metrics(self):
+        metrics = Metrics()
+        script = ["msg", "error", "msg"]
+        agent = DynamicAgent(metrics)
+        summary = agent.converse(script)
+        self.assertEqual(summary["turns"], 3)
+        self.assertEqual(summary["tasks_completed"], 1)
+        self.assertEqual(summary["errors"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `metrics.py` with counters for turns, tasks completed, errors and placeholder CSAT
- create `StaticAgent` and `DynamicAgent` using the metrics
- expose summary information from each agent
- document metrics in README
- add tests validating metric aggregation

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b0088803483208cfd376b75cd04d9