### PR TITLE
Add side-by-side agent UI

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,3 +37,14 @@ python -m dynamicreasoning.cli compare metrics.csv
 ```
 
 Running these commands produces JSON logs and CSV metrics that help evaluate how the dynamic agent performs versus the static one.
+
+## Side-by-Side UI
+
+A minimal graphical interface is provided to compare both agents with the same conversation script.
+Run it with:
+
+```bash
+python -m ui.side_by_side
+```
+
+Enter one step per line and press **Run** to display the metrics for `StaticAgent` and `DynamicAgent` side by side.

--- a/dynamic_agent/__init__.py
+++ b/dynamic_agent/__init__.py
@@ -1,0 +1,32 @@
+"""Dynamic agent package providing planning utilities and a simple agent."""
+from metrics import Metrics
+
+
+class DynamicAgent:
+    """Simple agent using a dynamic script."""
+
+    def __init__(self, metrics: Metrics):
+        self.metrics = metrics
+
+    def converse(self, script):
+        """Run through a list of actions.
+
+        `script` is an iterable containing strings. When the string is
+        "error" an error is recorded.
+        """
+        for step in script:
+            self.metrics.record_turn()
+            if step == "error":
+                self.metrics.record_error()
+        self.metrics.record_task_completed()
+        return self.metrics.summary()
+
+
+from .knowledge_graph import KnowledgeGraph
+from .reasoning_engine import ReasoningEngine
+
+__all__ = [
+    "DynamicAgent",
+    "KnowledgeGraph",
+    "ReasoningEngine",
+]

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,0 +1,3 @@
+from .side_by_side import run
+
+__all__ = ["run"]

--- a/ui/side_by_side.py
+++ b/ui/side_by_side.py
@@ -1,0 +1,54 @@
+import tkinter as tk
+from metrics import Metrics
+from dynamic_agent import DynamicAgent
+from static_agent import StaticAgent
+
+
+def format_summary(summary: dict) -> str:
+    """Format the metrics summary for display."""
+    lines = [f"{k}: {v}" for k, v in summary.items()]
+    return "\n".join(lines)
+
+
+def run():
+    """Launch the side-by-side agent comparison UI."""
+    root = tk.Tk()
+    root.title("Agent Comparison")
+
+    tk.Label(root, text="Conversation script (one step per line):").pack(anchor="w")
+    script_text = tk.Text(root, width=60, height=10)
+    script_text.pack()
+
+    result_frame = tk.Frame(root)
+    result_frame.pack(fill="both", expand=True, pady=10)
+
+    tk.Label(result_frame, text="StaticAgent Metrics:").grid(row=0, column=0, sticky="w")
+    tk.Label(result_frame, text="DynamicAgent Metrics:").grid(row=0, column=1, sticky="w")
+
+    static_var = tk.StringVar()
+    dynamic_var = tk.StringVar()
+
+    tk.Label(result_frame, textvariable=static_var, justify="left").grid(row=1, column=0, padx=10, sticky="nw")
+    tk.Label(result_frame, textvariable=dynamic_var, justify="left").grid(row=1, column=1, padx=10, sticky="nw")
+
+    def on_run():
+        raw = script_text.get("1.0", tk.END)
+        lines = [line.strip() for line in raw.strip().splitlines() if line.strip()]
+        metrics_static = Metrics()
+        metrics_dynamic = Metrics()
+
+        dyn_agent = DynamicAgent(metrics_dynamic)
+        static_agent = StaticAgent(metrics_static, turns=len(lines))
+
+        dyn_summary = dyn_agent.converse(lines)
+        static_summary = static_agent.converse()
+
+        dynamic_var.set(format_summary(dyn_summary))
+        static_var.set(format_summary(static_summary))
+
+    tk.Button(root, text="Run", command=on_run).pack(pady=5)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- expose `DynamicAgent` via `dynamic_agent.__init__`
- add new Tkinter UI to compare agents on one conversation
- document how to launch the side-by-side UI

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b08f41d8c83208d71c71cdbc17979