### PR TITLE
Add BFS planning and adjacency lists

### DIFF
--- a/dynamic_agent/knowledge_graph.py
+++ b/dynamic_agent/knowledge_graph.py
@@ -1,12 +1,24 @@
 class KnowledgeGraph:
-    """Simple knowledge graph storing facts as (subject, relation, object) triples."""
+    """Simple knowledge graph storing facts and adjacency information."""
 
     def __init__(self):
+        # All facts are stored to allow inspection and searching by tests or
+        # other tooling.  Using a ``set`` ensures no duplicate triples are
+        # inserted.
         self._facts = set()
+
+        # Adjacency list mapping ``subject -> relation -> set(objects)``.  This
+        # structure enables efficient lookup of neighbour entities without having
+        # to iterate over all facts on every call.
+        self._adj = {}
 
     def add_fact(self, subject, relation, obj):
         """Add a fact triple to the graph."""
+        if (subject, relation, obj) in self._facts:
+            return
+
         self._facts.add((subject, relation, obj))
+        self._adj.setdefault(subject, {}).setdefault(relation, set()).add(obj)
 
     def get_facts_by_entity(self, entity):
         """Return all facts where the given entity appears as subject or object."""
@@ -27,9 +39,11 @@ class KnowledgeGraph:
             If provided, only relations in this collection are considered.
         """
         neighbors = []
-        for s, r, o in self._facts:
-            if s == entity and (relations is None or r in relations):
-                neighbors.append((o, r))
+        rel_map = self._adj.get(entity, {})
+        for rel, objs in rel_map.items():
+            if relations is None or rel in relations:
+                for obj in objs:
+                    neighbors.append((obj, rel))
         return neighbors
 
     def __len__(self):

--- a/dynamic_agent/reasoning_engine.py
+++ b/dynamic_agent/reasoning_engine.py
@@ -41,3 +41,9 @@ class ReasoningEngine:
                     visited.add(neighbor)
                     queue.append((neighbor, path + [(node, rel, neighbor)]))
         return []
+
+    # ------------------------------------------------------------------
+    # Backwards compatibility -------------------------------------------------
+    def plan(self, start, goal, relations=None):
+        """Return a plan using :meth:`generate_plan` for compatibility."""
+        return self.generate_plan(start, goal, relations)

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -17,3 +17,19 @@ def test_get_facts_by_relation():
     kg.add_fact('dog', 'likes', 'bone')
     facts = kg.get_facts_by_relation('likes')
     assert len(facts) == 2
+
+
+def test_neighbors():
+    kg = KnowledgeGraph()
+    kg.add_fact('A', 'r1', 'B')
+    kg.add_fact('A', 'r2', 'C')
+
+    # Unfiltered neighbours should include both edges regardless of insertion
+    # order.
+    assert set(kg.neighbors('A')) == {('B', 'r1'), ('C', 'r2')}
+
+    # Relation filtering should restrict results.
+    assert set(kg.neighbors('A', relations={'r1'})) == {('B', 'r1')}
+
+    # Entities without outgoing edges should yield an empty list.
+    assert kg.neighbors('D') == []

--- a/tests/test_reasoning_engine.py
+++ b/tests/test_reasoning_engine.py
@@ -18,3 +18,10 @@ def test_generate_plan_relation_filter():
     engine = ReasoningEngine(kg)
     plan = engine.generate_plan('A', 'C', relations={'r1'})
     assert plan == []
+
+
+def test_plan_wrapper():
+    kg = KnowledgeGraph()
+    kg.add_fact('A', 'next', 'B')
+    engine = ReasoningEngine(kg)
+    assert engine.plan('A', 'B') == engine.generate_plan('A', 'B')


### PR DESCRIPTION
## Summary
- expand `KnowledgeGraph` with adjacency lists and update `neighbors`
- add a compatibility `plan()` wrapper to `ReasoningEngine`
- test adjacency via `neighbors()`
- test `plan()` wrapper

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b0cfff4248320a7a03b5d058cd93f