### PR TITLE
Improve docs for ReasoningEngine

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,31 @@ The reasoning engine evaluates the knowledge graph to choose actions dynamically
 4. Execute the best action and update the state.
 5. Repeat until the goal is achieved or no actions remain.
 
-This approach lets the agent adapt to failures or new information at runtime.
+This approach lets the agent adapt to failures or new information at runtime. The
+`ReasoningEngine` queries the `KnowledgeGraph` for neighboring nodes and uses a
+breadth‑first search (BFS) to connect a start entity to a goal entity. Each
+traversed edge forms a `(subject, relation, object)` triple in the returned plan.
+
+### Configuring relationships for BFS planning
+
+The optional ``relations`` argument restricts which edge types the BFS explores.
+Supplying a set of relation names helps focus the plan on specific connections.
+
+```python
+from dynamic_agent.knowledge_graph import KnowledgeGraph
+from dynamic_agent.reasoning_engine import ReasoningEngine
+
+kg = KnowledgeGraph()
+kg.add_fact("A", "next", "B")
+kg.add_fact("B", "blocks", "C")
+engine = ReasoningEngine(kg)
+
+# Only follow "next" edges during planning
+plan = engine.generate_plan("A", "C", relations={"next"})
+```
+
+In this case the ``blocks`` relation is ignored and the plan only contains the
+allowed ``next`` edge.
 
 ## Running the CLI
 
@@ -48,3 +72,13 @@ python -m ui.side_by_side
 ```
 
 Enter one step per line and press **Run** to display the metrics for `StaticAgent` and `DynamicAgent` side by side.
+
+## Running Tests
+
+Execute the test suite from the repository root:
+
+```bash
+PYTHONPATH=. pytest
+```
+
+All tests should pass and the output will contain a summary similar to ``6 passed``. Any failures are reported with stack traces to help diagnose issues.


### PR DESCRIPTION
## Summary
- clarify how the ReasoningEngine uses the knowledge graph
- show how to limit BFS planning by relation
- document how to run the test suite

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b0d0810b48320a2a4725fb1af6320