### PR TITLE
Add agent tests

### DIFF
--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,19 @@
+import pytest
+from dynamic_agent.knowledge_graph import KnowledgeGraph
+from static_agent import StaticAgent
+from metrics import Metrics
+
+
+def test_duplicate_cancel_action():
+    kg = KnowledgeGraph()
+    kg.add_fact('user', 'cancel', 'task1')
+    kg.add_fact('user', 'cancel', 'task1')
+    assert len(kg.get_facts_by_relation('cancel')) == 1
+    assert len(kg) == 1
+
+
+def test_static_agent_unknown_intent():
+    metrics = Metrics()
+    agent = StaticAgent(metrics)
+    with pytest.raises(AttributeError):
+        agent.handle_intent('unknown')


### PR DESCRIPTION
## Summary
- ensure cancellation requests don't duplicate entries in the KnowledgeGraph
- add coverage for unknown intents in StaticAgent

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b0d0adfa4832096b4fb804f842436