### PR TITLE
Add simple web UI for agent comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,14 @@ PYTHONPATH=. pytest
 
 For detailed documentation, including how the knowledge graph works and how to
 launch the side-by-side UI, see [docs/README.md](docs/README.md).
+
+## Web UI
+
+A small web interface is provided under `web/`. Start it locally with:
+
+```bash
+python web_server.py
+```
+
+Then open `http://localhost:8000` in your browser. The same code can be
+deployed on Vercel using `api/compare.py` as a serverless function.

--- a/api/compare.py
+++ b/api/compare.py
@@ -1,0 +1,27 @@
+import json
+from web_api import compare_agents
+
+
+def app(environ, start_response):
+    """WSGI application returning agent metrics as JSON."""
+    if environ.get("REQUEST_METHOD") != "POST":
+        start_response("405 Method Not Allowed", [("Content-Type", "text/plain")])
+        return [b"Method Not Allowed"]
+
+    try:
+        length = int(environ.get("CONTENT_LENGTH", 0))
+    except ValueError:
+        length = 0
+    body = environ["wsgi.input"].read(length).decode()
+    try:
+        data = json.loads(body) if body else {}
+    except json.JSONDecodeError:
+        data = {}
+    script_text = data.get("script", "")
+    script_lines = [line.strip() for line in script_text.splitlines() if line.strip()]
+
+    result = compare_agents(script_lines)
+    payload = json.dumps(result).encode()
+
+    start_response("200 OK", [("Content-Type", "application/json")])
+    return [payload]

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,4 +71,15 @@ Run it with:
 python -m ui.side_by_side
 ```
 
-Enter one step per line and press **Run** to display the metrics for `StaticAgent` and `DynamicAgent` side by side
+Enter one step per line and press **Run** to display the metrics for `StaticAgent` and `DynamicAgent` side by side.
+
+## Web UI
+
+The `web/` directory contains a small browser interface. Launch it locally with:
+
+```bash
+python web_server.py
+```
+
+Open `http://localhost:8000` and paste your conversation script to compare the
+agents. The same files can be deployed on Vercel using `api/compare.py`.

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -1,0 +1,9 @@
+from web_api import compare_agents
+
+
+def test_compare_agents():
+    script = ["msg", "error", "msg"]
+    result = compare_agents(script)
+    assert result["static"]["turns"] == 3
+    assert result["static"]["errors"] == 0
+    assert result["dynamic"]["errors"] == 1

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const run = document.getElementById('run');
+  run.addEventListener('click', async () => {
+    const script = document.getElementById('script').value;
+    const res = await fetch('/api/compare', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ script })
+    });
+    if (!res.ok) {
+      alert('Request failed');
+      return;
+    }
+    const data = await res.json();
+    document.getElementById('static').textContent = JSON.stringify(data.static, null, 2);
+    document.getElementById('dynamic').textContent = JSON.stringify(data.dynamic, null, 2);
+  });
+});

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Agent Comparison</title>
+  <script defer src="app.js"></script>
+  <style>
+    body { font-family: sans-serif; margin: 2rem; }
+    textarea { width: 100%; height: 150px; }
+    pre { background: #f0f0f0; padding: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Agent Comparison</h1>
+  <label for="script">Conversation script (one step per line):</label><br />
+  <textarea id="script"></textarea><br />
+  <button id="run">Run</button>
+  <div style="display:flex; gap:2rem; margin-top:1rem;">
+    <div>
+      <h3>StaticAgent Metrics</h3>
+      <pre id="static"></pre>
+    </div>
+    <div>
+      <h3>DynamicAgent Metrics</h3>
+      <pre id="dynamic"></pre>
+    </div>
+  </div>
+</body>
+</html>

--- a/web_api.py
+++ b/web_api.py
@@ -1,0 +1,17 @@
+from metrics import Metrics
+from dynamic_agent import DynamicAgent
+from static_agent import StaticAgent
+
+
+def compare_agents(script_lines):
+    """Run both agents on the given script lines."""
+    metrics_static = Metrics()
+    metrics_dynamic = Metrics()
+
+    dyn_agent = DynamicAgent(metrics_dynamic)
+    static_agent = StaticAgent(metrics_static, turns=len(script_lines))
+
+    dynamic_summary = dyn_agent.converse(list(script_lines))
+    static_summary = static_agent.converse()
+
+    return {"static": static_summary, "dynamic": dynamic_summary}

--- a/web_server.py
+++ b/web_server.py
@@ -1,0 +1,8 @@
+from wsgiref.simple_server import make_server
+from api.compare import app
+
+
+if __name__ == "__main__":
+    with make_server("", 8000, app) as server:
+        print("Serving on http://localhost:8000")
+        server.serve_forever()


### PR DESCRIPTION
## Summary
- create `web_api.compare_agents` helper and `api/compare.py` WSGI endpoint
- add a minimal web interface under `web/`
- provide `web_server.py` to run the app locally
- document usage of the web UI in README and docs
- test new helper logic

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b1e9814a08320a9d5a1c418adba88