### PR TITLE
Add graph persistence, new metrics and packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ PYTHONPATH=. pytest
 For detailed documentation, including how the knowledge graph works and how to
 launch the side-by-side UI, see [docs/README.md](docs/README.md).
 
+After installing the package you can run the CLI directly:
+
+```bash
+pip install -e .
+dynamicreasoning run dynamic --script my_script.txt --output out.json
+```
+The dynamic agent accepts ``--graph`` to load a JSON knowledge graph created
+with ``KnowledgeGraph.save``.
+
 ## Web UI
 
 A small web interface is provided under `web/`. Start it locally with:
@@ -28,5 +37,6 @@ A small web interface is provided under `web/`. Start it locally with:
 python web_server.py
 ```
 
-Then open `http://localhost:8000` in your browser. The same code can be
+Then open `http://localhost:8000` in your browser to use the interface. The
+same code can be
 deployed on Vercel using `api/compare.py` as a serverless function.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,10 @@ This document explains how the knowledge graph and reasoning engine function wit
 
 The knowledge graph captures tasks and relationships as triples stored in `graph.yaml`. Each node represents an action or piece of contextual information. Edges denote prerequisites or consequences. When the CLI launches the dynamic agent it loads this file into memory, allowing the reasoning engine to query for possible next steps based on the current state.
 
+Graphs can now be saved and loaded from JSON files using ``KnowledgeGraph.save``
+and ``KnowledgeGraph.load``. This makes it easy to persist larger graphs and
+reuse them across sessions.
+
 ## Reasoning Engine
 
 The reasoning engine evaluates the knowledge graph to choose actions dynamically:
@@ -52,6 +56,9 @@ python -m dynamicreasoning.cli run static --turns 3 --output runs/static.json
 
 # Dynamic agent
 python -m dynamicreasoning.cli run dynamic --script script.txt --output runs/dynamic.json
+# Using a custom knowledge graph
+python -m dynamicreasoning.cli run dynamic --script script.txt \
+    --graph graph.json --output runs/dynamic.json
 
 # Metrics
 python -m dynamicreasoning.cli metrics runs/static.json runs/dynamic.json --output metrics.csv

--- a/dynamic_agent/__init__.py
+++ b/dynamic_agent/__init__.py
@@ -16,6 +16,7 @@ class DynamicAgent:
         """
         for step in script:
             self.metrics.record_turn()
+            self.metrics.log_event({"agent": "dynamic", "step": step})
             if step == "error":
                 self.metrics.record_error()
         self.metrics.record_task_completed()

--- a/dynamic_agent/knowledge_graph.py
+++ b/dynamic_agent/knowledge_graph.py
@@ -12,6 +12,13 @@ class KnowledgeGraph:
         # to iterate over all facts on every call.
         self._adj = {}
 
+    # ------------------------------------------------------------------
+    # Basic graph manipulation utilities
+
+    def has_fact(self, subject, relation, obj):
+        """Return True if the triple exists in the graph."""
+        return (subject, relation, obj) in self._facts
+
     def add_fact(self, subject, relation, obj):
         """Add a fact triple to the graph."""
         if (subject, relation, obj) in self._facts:
@@ -19,6 +26,29 @@ class KnowledgeGraph:
 
         self._facts.add((subject, relation, obj))
         self._adj.setdefault(subject, {}).setdefault(relation, set()).add(obj)
+
+    # ------------------------------------------------------------------
+    # Persistence helpers ----------------------------------------------------
+
+    def save(self, path):
+        """Serialize the graph to a JSON file."""
+        import json
+
+        data = list(self._facts)
+        with open(path, "w") as f:
+            json.dump(data, f)
+
+    @classmethod
+    def load(cls, path):
+        """Load a graph from a JSON file and return a new instance."""
+        import json
+
+        kg = cls()
+        with open(path, "r") as f:
+            data = json.load(f)
+        for s, r, o in data:
+            kg.add_fact(s, r, o)
+        return kg
 
     def get_facts_by_entity(self, entity):
         """Return all facts where the given entity appears as subject or object."""

--- a/dynamic_agent/reasoning_engine.py
+++ b/dynamic_agent/reasoning_engine.py
@@ -13,7 +13,7 @@ class ReasoningEngine:
     def __init__(self, graph):
         self.graph = graph
 
-    def generate_plan(self, start, goal, relations=None):
+    def generate_plan(self, start, goal, relations=None, max_depth=None):
         """Generate a plan (a sequence of triples) from start to goal.
 
         The engine performs a breadth-first search over the relations in the
@@ -29,16 +29,23 @@ class ReasoningEngine:
         relations : Iterable[str] or None
             Allowed relations to traverse. ``None`` means all relations are
             allowed.
+        max_depth : int or None
+            Optional maximum search depth for the plan. ``None`` means no
+            depth limit.
         """
         queue = deque([(start, [])])
         visited = {start}
+        depth_map = {start: 0}
         while queue:
             node, path = queue.popleft()
             if node == goal:
                 return path
+            if max_depth is not None and depth_map[node] >= max_depth:
+                continue
             for neighbor, rel in self.graph.neighbors(node, relations):
                 if neighbor not in visited:
                     visited.add(neighbor)
+                    depth_map[neighbor] = depth_map[node] + 1
                     queue.append((neighbor, path + [(node, rel, neighbor)]))
         return []
 

--- a/dynamicreasoning/__init__.py
+++ b/dynamicreasoning/__init__.py
@@ -1,0 +1,3 @@
+__version__ = '0.1.0'
+
+from .cli import main

--- a/dynamicreasoning/cli.py
+++ b/dynamicreasoning/cli.py
@@ -21,7 +21,19 @@ def run_dynamic(args):
         script = [line.strip() for line in f if line.strip()]
     metrics = Metrics()
     agent = DynamicAgent(metrics)
+
+    if args.graph:
+        from dynamic_agent.knowledge_graph import KnowledgeGraph
+        from dynamic_agent.reasoning_engine import ReasoningEngine
+
+        kg = KnowledgeGraph.load(args.graph)
+        engine = ReasoningEngine(kg)
+        plan = engine.generate_plan(script[0], script[-1], max_depth=len(script))
+    else:
+        plan = []
+
     summary = agent.converse(script)
+    summary["plan"] = plan
     with open(args.output, "w") as f:
         json.dump(summary, f)
 

--- a/metrics.py
+++ b/metrics.py
@@ -5,30 +5,52 @@ class Metrics:
         self.reset()
 
     def reset(self):
+        import time
+
+        self.start_time = time.time()
         self.tasks_completed = 0
         self.turns = 0
         self.errors = 0
         self.csat_scores = []  # placeholder for future CSAT metrics
+        self.events = []
 
     def record_turn(self):
         self.turns += 1
+        self.log_event({"type": "turn", "count": self.turns})
 
     def record_task_completed(self):
         self.tasks_completed += 1
+        self.log_event({"type": "task_completed"})
 
     def record_error(self):
         self.errors += 1
+        self.log_event({"type": "error"})
 
     def record_csat(self, score):
         self.csat_scores.append(score)
+        self.log_event({"type": "csat", "value": score})
+
+    def log_event(self, event: dict):
+        """Record an arbitrary event in the conversation log."""
+        self.events.append(event)
 
     def summary(self):
+        import time
+
         avg_csat = None
         if self.csat_scores:
             avg_csat = sum(self.csat_scores) / len(self.csat_scores)
+        elapsed = time.time() - self.start_time
+        success_rate = None
+        completed_or_errors = self.tasks_completed + self.errors
+        if completed_or_errors:
+            success_rate = self.tasks_completed / completed_or_errors
         return {
             "tasks_completed": self.tasks_completed,
             "turns": self.turns,
             "errors": self.errors,
             "avg_csat": avg_csat,
+            "elapsed_time": elapsed,
+            "success_rate": success_rate,
+            "events": list(self.events),
         }

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='dynamicreasoning',
+    version='0.1.0',
+    packages=find_packages(include=['dynamicreasoning', 'dynamic_agent', 'ui']),
+    py_modules=['metrics', 'static_agent', 'enhanced_agents', 'web_api', 'web_server'],
+    entry_points={
+        'console_scripts': [
+            'dynamicreasoning=dynamicreasoning.cli:main',
+        ]
+    },
+    python_requires='>=3.8',
+)

--- a/static_agent.py
+++ b/static_agent.py
@@ -9,7 +9,8 @@ class StaticAgent:
         self.turns = turns
 
     def converse(self):
-        for _ in range(self.turns):
+        for i in range(self.turns):
             self.metrics.record_turn()
+            self.metrics.log_event({"agent": "static", "turn": i + 1})
         self.metrics.record_task_completed()
         return self.metrics.summary()

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -33,3 +33,12 @@ def test_neighbors():
 
     # Entities without outgoing edges should yield an empty list.
     assert kg.neighbors('D') == []
+
+
+def test_save_and_load(tmp_path):
+    kg = KnowledgeGraph()
+    kg.add_fact('a', 'b', 'c')
+    path = tmp_path / 'graph.json'
+    kg.save(path)
+    kg2 = KnowledgeGraph.load(path)
+    assert kg2.has_fact('a', 'b', 'c')

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -14,6 +14,8 @@ class MetricsTests(unittest.TestCase):
         self.assertEqual(summary["tasks_completed"], 1)
         self.assertEqual(summary["errors"], 0)
         self.assertIsNone(summary["avg_csat"])
+        assert "elapsed_time" in summary
+        assert summary["success_rate"] == 1.0
 
     def test_dynamic_agent_metrics(self):
         metrics = Metrics()
@@ -23,6 +25,7 @@ class MetricsTests(unittest.TestCase):
         self.assertEqual(summary["turns"], 3)
         self.assertEqual(summary["tasks_completed"], 1)
         self.assertEqual(summary["errors"], 1)
+        assert summary["success_rate"] == 0.5
 
 
 if __name__ == "__main__":

--- a/tests/test_reasoning_engine.py
+++ b/tests/test_reasoning_engine.py
@@ -25,3 +25,12 @@ def test_plan_wrapper():
     kg.add_fact('A', 'next', 'B')
     engine = ReasoningEngine(kg)
     assert engine.plan('A', 'B') == engine.generate_plan('A', 'B')
+
+
+def test_max_depth_limit():
+    kg = KnowledgeGraph()
+    kg.add_fact('A', 'r', 'B')
+    kg.add_fact('B', 'r', 'C')
+    engine = ReasoningEngine(kg)
+    # Depth limit of 1 should not reach C
+    assert engine.generate_plan('A', 'C', max_depth=1) == []

--- a/web/app.js
+++ b/web/app.js
@@ -14,5 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const data = await res.json();
     document.getElementById('static').textContent = JSON.stringify(data.static, null, 2);
     document.getElementById('dynamic').textContent = JSON.stringify(data.dynamic, null, 2);
+    const events = [...(data.static.events || []), ...(data.dynamic.events || [])];
+    document.getElementById('events').textContent = events.map(e => JSON.stringify(e)).join('\n');
   });
 });

--- a/web/index.html
+++ b/web/index.html
@@ -7,7 +7,9 @@
   <style>
     body { font-family: sans-serif; margin: 2rem; }
     textarea { width: 100%; height: 150px; }
-    pre { background: #f0f0f0; padding: 1rem; }
+    pre { background: #f0f0f0; padding: 1rem; border-radius: 4px; }
+    #output { display: flex; gap: 2rem; margin-top: 1rem; }
+    #output div { flex: 1; }
   </style>
 </head>
 <body>
@@ -15,7 +17,7 @@
   <label for="script">Conversation script (one step per line):</label><br />
   <textarea id="script"></textarea><br />
   <button id="run">Run</button>
-  <div style="display:flex; gap:2rem; margin-top:1rem;">
+  <div id="output">
     <div>
       <h3>StaticAgent Metrics</h3>
       <pre id="static"></pre>
@@ -25,5 +27,7 @@
       <pre id="dynamic"></pre>
     </div>
   </div>
+  <h3>Event Log</h3>
+  <pre id="events"></pre>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- persist knowledge graphs to JSON
- add max_depth search limit
- log conversation events and compute success rate
- document graph persistence and CLI usage
- add setup.py package
- show events in the web UI
- tests cover persistence, depth limit and metrics

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b240d563883209efb1e0b7a4d77de